### PR TITLE
Fix country_of_manufacture case

### DIFF
--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -21,7 +21,7 @@
         <attribute code="sendcloud_service_point_postnumber" type="string"/>
     </extension_attributes>
     <extension_attributes for="Magento\Sales\Api\Data\OrderItemInterface">
-        <attribute code="Country_of_manufacture" type="string"/>
+        <attribute code="country_of_manufacture" type="string"/>
         <attribute code="hs_code" type="string"/>
     </extension_attributes>
 </config>


### PR DESCRIPTION
Hello,

I just installed the module on a Magento 2.4.2 and I have the following error on an order page in back-office:
```
main.CRITICAL: Error: Call to undefined method Magento\Sales\Api\Data\OrderItemExtension::setCountryOfManufacture() in /vendor/sendcloud/sendcloud/Plugin/Order/OrderItemRepository.php:91
```

This PR fixes it.