### PR TITLE
Safeguard to prevent crashing page

### DIFF
--- a/Observer/AddSendCloudVariable.php
+++ b/Observer/AddSendCloudVariable.php
@@ -13,6 +13,9 @@ class AddSendCloudVariable implements ObserverInterface
     public function execute(Observer $observer)
     {
         $transportObject = $observer->getEvent()->getData('transportObject');
+        if ($transportObject === null) {
+            return;
+        }
         $this->order = $transportObject->getOrder();
 
         if ($this->order !== null && $this->order->getSendcloudServicePointId()) {


### PR DESCRIPTION
When transportObject is empty, creating shipment will crash due to getOrder() on null