### PR TITLE
Fix for free shipping threshold

### DIFF
--- a/Model/Carrier/SendCloud.php
+++ b/Model/Carrier/SendCloud.php
@@ -191,7 +191,7 @@ class SendCloud extends Tablerate
         }
 
         $method = $this->createShippingMethod($amount, $amount);
-        if ($this->getConfigData('free_shipping_enable') &&
+        if ($this->getConfigData('free_shipping_enable') && $this->getConfigData('free_shipping_subtotal') &&
             $this->getConfigData('free_shipping_subtotal') <= $request->getBaseSubtotalInclTax()) {
             $method->setPrice('0.00');
             $method->setCost('0.00');


### PR DESCRIPTION
Add check to make sure there is an actual value set for the free shipping subtotal. It can happen that the free shipping is enabled but no price is set in config. This will result in free shipping.